### PR TITLE
fix subnet name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ resource "aviatrix_vpc" "single_region" {
   aviatrix_transit_vpc = false
   aviatrix_firenet_vpc = false
   subnets {
-    name   = "avx-${var.region}-spoke"
+    name   = "avx-${var.name}-spoke"
     cidr   = var.cidr
     region = var.region
   }


### PR DESCRIPTION
fixed the subnet name for "no HA" GW.  could not create multiple VPCs due to overlapping subnet names